### PR TITLE
simplified version of MSKs `bib-registry`

### DIFF
--- a/sbpy/bib/__init__.py
+++ b/sbpy/bib/__init__.py
@@ -1,1 +1,1 @@
-from .bib import Bib
+from .bib import *

--- a/sbpy/bib/bib.py
+++ b/sbpy/bib/bib.py
@@ -13,96 +13,27 @@ Example
 >>> from sbpy import bib, data
 >>> bib.track()
 >>> eph = data.Ephem.from_horizons('encke')
->>> citations = bib.report()
->>> citations.to_text()
+>>> bib.to_text()
 JPL Horizons:
   implementation: 1996DPS....28.2504G
 
-Classes
--------
-Bib : A container for bibilography entries.
 
 Functions
 ---------
 register : Register a citation.
-report   : Report registered citations.
 status   : Bibliography tracking status.
 stop     : Stop bibliography tracking.
 track    : Start bibliography tracking.
+reset    : clear bibliography.
+to_text  : output bibliography in clear text
+to_bibtex: output bibliography in bibtex format
 
 """
 
-__all__ = ['Bib', 'register', 'report', 'status', 'stop', 'track']
+__all__ = ['register', 'reset', 'status', 'stop', 'track',
+           'to_text', 'to_bibtex']
 
 from collections import OrderedDict
-
-class Bib():
-    """Bibliography class.
-
-    References for specific tasks are provided as bibcode elements that can be queried at `ADS`_.
-
-    .. _ADS: http://adsabs.harvard.edu
-    """
-
-    def __init__(self):
-        self.bib = OrderedDict()
-
-    def __setitem__(self, task, payload):
-        """Set references for a specific task
-
-        Parameters
-        ----------
-        task : str, mandatory
-            name of the task generating the reference
-        payload : dict, mandatory
-            a dictionary with bibcodes for several aspects of the task, e.g., 
-            one could cite one paper for the general `method` and one for the
-            actual `implementation` used in SBPy
-        """
-        self.bib[task] = payload
-
-    def __getitem__(self, ident):
-        """Return the references for a specific task or for the n-th task""" 
-        if isinstance(ident, str):
-            return self.bib[ident]
-        elif isinstance(ident, int):
-            key = list(self.bib.keys())[idx]
-            return {'task': key, 'references': self.bib[key]}
-        
-    def __iter__(self):
-        return self.bib
-            
-    def __len__(self):
-        return len(self.bib)
-    
-    @property
-    def tasks(self):
-        return list(self.bib.keys())
-    
-    def to_text(self):
-        """convert bibcodes to human readable text
-
-        not yet implemented
-        """
-        output = ''
-        for ref in self.bib: #__iter__():
-            output += '{:s}:\n'.format(ref)
-            for key, val in self.__getitem__(ref).items():
-                # transform val to ads(val)
-                output += '  {:s}: {:s}\n'.format(key, val)
-        return output
-
-    def to_bibtex(self):
-        """ convert bibcodes to LATeX bibtex
-
-        not yet implemented
-        """
-        output = ''
-        for ref in self.bib: #__iter__():
-            for key, val in self.__getitem__(ref).items():
-                # transform val to ads.bibtex(val)
-                output += '% {:s}/{:s}:\n{:s}\n'.format(ref, key, val)
-        return output
 
 def register(task, citations):
     """Register a citation with the `sbpy` bibliography.
@@ -122,14 +53,10 @@ def register(task, citations):
     if _track:
         _bibliography[task] = citations
 
-def report():
-    """Report tracked `sbpy` citations."""
-    return _bibliography
-
 def reset():
     """Reset `sbpy` bibliography tracking."""
     global _bibliography
-    _bibliography = Bib()
+    _bibliography = OrderedDict()
 
 def stop():
     """Disable `sbpy` bibliography tracking."""
@@ -152,5 +79,40 @@ def track():
     global _track
     _track = True
 
+
+def to_text():
+    """convert bibcodes to human readable text
+    
+    not yet implemented
+    """
+    output = ''
+    for task, ref in _bibliography.items():
+        output += '{:s}:\n'.format(task)
+        try:
+            for key, val in ref.items():
+                # transform val to ads(val)
+                output += '  {:s}: {:s}\n'.format(key, val)
+        except:
+            pass
+        
+    return output
+
+def to_bibtex():
+    """ convert bibcodes to LATeX bibtex
+    
+        not yet implemented
+    """
+    output = ''
+    for task, ref in _bibliography.items():
+        try:
+            for key, val in ref.items():
+                # transform val to ads.bibtex(val)
+                output += '% {:s}/{:s}:\n{:s}\n'.format(task, key, val)
+        except:
+            pass
+
+    return output
+
+    
 _track = False  # default is no bibliography tracking
-_bibliography = Bib()
+_bibliography = OrderedDict()


### PR DESCRIPTION
replace `Bib` class with simpler approach using MSKs `bib-registry` draft without the underlying class structure