### PR TITLE
Bibliography functions

### DIFF
--- a/sbpy/bib/core.py
+++ b/sbpy/bib/core.py
@@ -5,14 +5,14 @@ SBPy Bibliography Tracking Module
 =================================
 
 `sbpy` classes and functions can automatically report citations to the
-user through a biliography registry.  Use `track` to enable citation
+user through a bibliography registry.  Use `track` to enable citation
 tracking, and `citations` to report the references used.
 
 Example
 -------
 >>> from sbpy import bib, data
 >>> bib.track()
->>> eph = data.Ephem.from_horizons('encke')
+>>> eph = data.Ephem.from_horizons('encke', epoch=None, observatory='500')
 >>> bib.to_text()
 JPL Horizons:
   implementation: 1996DPS....28.2504G
@@ -62,7 +62,7 @@ def stop():
     """Disable `sbpy` bibliography tracking."""
     global _track
     _track = False
-    
+
 def status():
     """Report `sbpy` bibliography tracking status.
 
@@ -82,7 +82,7 @@ def track():
 
 def to_text():
     """convert bibcodes to human readable text
-    
+
     not yet implemented
     """
     output = ''
@@ -94,12 +94,12 @@ def to_text():
                 output += '  {:s}: {:s}\n'.format(key, val)
         except:
             pass
-        
+
     return output
 
 def to_bibtex():
-    """ convert bibcodes to LATeX bibtex
-    
+    """ convert bibcodes to LaTeX bibtex
+
         not yet implemented
     """
     output = ''
@@ -113,6 +113,6 @@ def to_bibtex():
 
     return output
 
-    
+
 _track = False  # default is no bibliography tracking
 _bibliography = OrderedDict()

--- a/sbpy/bib/core.py
+++ b/sbpy/bib/core.py
@@ -83,31 +83,61 @@ def track():
 def to_text():
     """convert bibcodes to human readable text
 
-    not yet implemented
+    Returns
+    -------
+    text : string
+      Text with human-readable information retrieved from ADS using the
+      bibcodes.
     """
+    import ads
+
     output = ''
     for task, ref in _bibliography.items():
         output += '{:s}:\n'.format(task)
         try:
             for key, val in ref.items():
-                # transform val to ads(val)
-                output += '  {:s}: {:s}\n'.format(key, val)
+                # request needed fields to avoid lazy loading
+                paper = list(ads.SearchQuery(bibcode=val, fl=['first_author',
+                                                              'author',
+                                                              'year']))[0]
+                if len(paper.author) > 4:
+                    author = '{:s} et al.'.format(paper.first_author.split(',')[0])
+                elif len(paper.author) > 1:
+                    author = ','.join([au.split(',')[0] for au in
+                                       paper.author[:-1]])
+                    author += ' & {:s}'.format(paper.author[-1].split(',')[0])
+                else:
+                    # single author
+                    author = paper.first_author.split(',')[0]
+
+                output += '  {:s}: {:s} {:s}, {:s}\n'.format(key, author,
+                                                             paper.year, val)
         except:
             pass
 
     return output
 
 def to_bibtex():
-    """ convert bibcodes to LaTeX bibtex
+    """ convert bibcodes to LaTeX BibTeX
 
-        not yet implemented
+    Returns
+    -------
+    text : string
+      ADS BibTex entries for all the bibliographic items.  Uses a query to the
+      export service to get the BibTeX for each reference.
     """
+    import ads
+
     output = ''
     for task, ref in _bibliography.items():
         try:
             for key, val in ref.items():
-                # transform val to ads.bibtex(val)
-                output += '% {:s}/{:s}:\n{:s}\n'.format(task, key, val)
+                # This method to get bibtex records avoids using multiple calls
+                # to the API that may impact rate limits
+                # https://github.com/adsabs/adsabs-dev-api/blob/master/export.md
+                query = ads.ExportQuery(val, format='bibtex')
+                bibtex = query.execute()
+                output += '% {:s}/{:s}:\n{:s}\n'.format(task, key, bibtex)
         except:
             pass
 

--- a/sbpy/bib/tests/data/neatm.bib
+++ b/sbpy/bib/tests/data/neatm.bib
@@ -1,0 +1,16 @@
+% sbpy.thermal.NEATM/method:
+@ARTICLE{1998Icar..131..291H,
+   author = {{Harris}, A.~W.},
+    title = "{A Thermal Model for Near-Earth Asteroids}",
+  journal = {\icarus},
+     year = 1998,
+    month = feb,
+   volume = 131,
+    pages = {291-301},
+      doi = {10.1006/icar.1997.5865},
+   adsurl = {http://adsabs.harvard.edu/abs/1998Icar..131..291H},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+

--- a/sbpy/bib/tests/test_bib.py
+++ b/sbpy/bib/tests/test_bib.py
@@ -1,0 +1,31 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+import os
+from astropy.tests.helper import remote_data
+from ...thermal import NEATM
+from .. import track, stop, reset, to_text, to_bibtex
+
+
+# get file path of a static data file for testing
+def data_path(filename):
+    data_dir = os.path.join(os.path.dirname(__file__), 'data')
+    return os.path.join(data_dir, filename)
+
+
+@remote_data
+def test_text():
+    track()
+    neatm = NEATM()
+    assert ['sbpy.thermal.NEATM:', 'method:', 'Harris', '1998,',
+            '1998Icar..131..291H'] == to_text().split()
+    reset()
+    stop()
+
+
+@remote_data
+def test_bibtex():
+    track()
+    neatm = NEATM()
+    with open(data_path('neatm.bib')) as bib_file:
+        assert bibtex == bib_file.read()
+    reset()
+    stop()


### PR DESCRIPTION
This implements the `to_text` and `to_bibtex` functions using the ads module to interact with the ADS.  It adds a new dependency on `ads` which is pip-installable and is the unofficial client to interact with the new [API](https://github.com/adsabs/adsabs-dev-api).