### PR TITLE
Update comet name to match whitespace and quote character

### DIFF
--- a/sbpy/data/names.py
+++ b/sbpy/data/names.py
@@ -61,8 +61,6 @@ class Names():
         'J95A01A'
         """
 
-        import math
-
         if isinstance(s, dict):
             ident = s
         else:
@@ -97,7 +95,8 @@ class Names():
             return (yr + let[0] + num + let[1])
         else:
             raise TargetNameParseError(('{} cannot be turned into a '
-                                        'packed number or designation').format(s))
+                                'packed number or designation').format(s))
+
 
     @staticmethod
     def parse_comet(s):
@@ -116,7 +115,7 @@ class Names():
         r : dict
         The dictionary contains the components identified from `s`:
         number, orbit type, designation, name, and/or fragment. If
-        none of these components are identfied, a
+        none of these components are identified, a
         `TargetNameParseError` is raised
 
         Raises
@@ -172,11 +171,11 @@ class Names():
 
         # define comet matching pattern
         pat = ('^(([1-9][0-9]*[PDCXAI]'
-               '(-[A-Z]{1,2})?)|[PDCXAI]/)'  # typ/number/fragm [0,1,2]
+               '(-[A-Z]{1,2})?)|[PDCXAI]/)' # typ/number/fragm [0,1,2]
                '|([-]?[0-9]{3,4}[ _][A-Z]{1,2}[0-9]{1,3}(-[1-9A-Z]{0,2})?)'
                # designation [3,4]
-               '|(([A-Z][a-z]?[A-Z]*[a-z]*[ -]?[A-Z]?[1-9]*[a-z]*)'
-               '( [1-9A-Z]{1,2})*)'  # name [5,6]
+               '|(([dvA-Z][a-z\']? ?[A-Z]*[a-z]*[ -]?[A-Z]?[1-9]*[a-z]*)'
+               '( [1-9A-Z]{1,2})*)' # name [5,6]
                )
 
         # regex patterns that will be rejected
@@ -242,7 +241,7 @@ class Names():
 
         Considers IAU-formatted permanent and new-style designations,
         as well as MPC packed designations and numbers. Note that
-        letter case is important. Parentheses are ignored in the parsing.        
+        letter case is important. Parentheses are ignored in the parsing.
         Parameters
         ----------
         s : string or list/array of strings
@@ -297,21 +296,20 @@ class Names():
         # packed numbers translation string
         pkd = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghifklmnopqrstuvwxyz'
 
-        pat = ('(([1-2][0-9]{0,3}[ _][A-Z]{2}[0-9]{0,3})'  # designation [0,1]
-               '|([1-9][0-9]{3}[ _](P-L|T-[1-3])))'  # Palomar-Leiden  [0,2,3]
-               '|([IJKL][0-9]{2}[A-Z][0-9a-z][0-9][A-Z])'  # packed desig [4]
-               '|([A-Za-z][0-9]{4})'  # packed number [5]
+        pat = ('(([1-2][0-9]{0,3}[ _][A-Z]{2}[0-9]{0,3})' # designation [0,1]
+               '|([1-9][0-9]{3}[ _](P-L|T-[1-3])))' # Palomar-Leiden  [0,2,3]
+               '|([IJKL][0-9]{2}[A-Z][0-9a-z][0-9][A-Z])' # packed desig [4]
+               '|([A-Za-z][0-9]{4})' # packed number [5]
                '|([A-Z][A-Z]*[a-z][a-z]*[^0-9]*'
                '[ -]?[A-Z]?[a-z]*[^0-9]*)'  # name [6]
                '|([1-9][0-9]*(\b|$| |_))')  # number [7,8]
 
         # regex patterns that will be rejected
-        rej_pat = ('([1-2][0-9]{0,3}[ _][A-Z][0-9]*(\b|$))'  # comet desig
-                   '|([1-9][0-9]*[PDCXAI]\b)'  # comet number
-                   '|([PDCXAI]/)'  # comet type
-                   # small-caps desig
-                   '|([1-2][0-9]{0,3}[ _][a-z]{2}[0-9]{0,3})'
-                   )
+        rej_pat = ('([1-2][0-9]{0,3}[ _][A-Z][0-9]*(\b|$))' # comet desig
+                   '|([1-9][0-9]*[PDCXAI]\b)' # comet number
+                   '|([PDCXAI]/)' # comet type
+                   '|([1-2][0-9]{0,3}[ _][a-z]{2}[0-9]{0,3})' # small-caps desig
+        )
 
         raw = s.translate(str.maketrans('()_', '   ')).strip()
 
@@ -385,7 +383,7 @@ class Names():
     @staticmethod
     def asteroid_or_comet(s):
         """Checks if an object is an asteroid, or a comet, based on its
-        identifier. 
+        identifier.
 
         Parameters
         ----------

--- a/sbpy/data/tests/test_names.py
+++ b/sbpy/data/tests/test_names.py
@@ -4,6 +4,7 @@
 comets = {
     '1P/Halley': {'type': 'P', 'number': 1, 'name': 'Halley'},
     '3D/Biela': {'type': 'D', 'number': 3, 'name': 'Biela'},
+    '6P/d\'Arrest': {'type': 'P', 'number': 6, 'name': 'd\'Arrest'},
     '9P/Tempel 1': {'type': 'P', 'number': 9, 'name': 'Tempel 1'},
     '73P/Schwassmann Wachmann 3 C': {'type': 'P', 'number': 73,
                                      'name': 'Schwassmann Wachmann 3 C'},
@@ -11,6 +12,7 @@ comets = {
                                        'fragment': 'C',
                                        'name': 'Schwassmann Wachmann 3 C'},
     '73P-BB': {'type': 'P', 'number': 73, 'fragment': 'BB'},
+    '122P/de Vico': {'type': 'P', 'number': 122, 'name': 'de Vico'},
     '322P': {'type': 'P', 'number': 322},
     'X/1106 C1': {'type': 'X', 'desig': '1106 C1'},
     'P/1994 N2 (McNaught-Hartley)': {'type': 'P', 'desig': '1994 N2',


### PR DESCRIPTION
This works for parsing comets with space or single quotes in their name as in `6P/d'Arrest` or `122P/de Vico` that I have added to the name tests. Ideally `findall` could return a single match with several groups to make it easier to parse the components (instead of a list of tuples for each group), but Iit seems that it is not really possible for comet names.

I also removed a `math` import that is not used.