### PR TITLE
Sun binning test set to 0.5% tolerance.

### DIFF
--- a/sbpy/spectroscopy/sun/tests/test_sun.py
+++ b/sbpy/spectroscopy/sun/tests/test_sun.py
@@ -9,20 +9,27 @@ try:
 except ImportError:
     HAS_SCIPY = False
 
+
 def test_default_sun_string():
     with default_sun.set('E490_2014'):
-        assert default_sun.get().description == sources.E490_2014['description']
-    
+        assert default_sun.get().description == sources.E490_2014[
+            'description']
+
     with default_sun.set('E490_2014LR'):
-        assert default_sun.get().description == sources.E490_2014LR['description']
+        assert default_sun.get().description == sources.E490_2014LR[
+            'description']
+
 
 @pytest.mark.remote_data
 def test_default_sun_string_remote():
     with default_sun.set('Kurucz1993'):
-        assert default_sun.get().description == sources.Kurucz1993['description']
-    
+        assert default_sun.get().description == sources.Kurucz1993[
+            'description']
+
     with default_sun.set('Castelli1996'):
-        assert default_sun.get().description == sources.Castelli1996['description']
+        assert default_sun.get().description == sources.Castelli1996[
+            'description']
+
 
 def test_sun_call_single():
     with default_sun.set('E490_2014'):
@@ -35,10 +42,11 @@ def test_sun_call_single():
         f = sun(0.55 * u.um, unit='W/(m2 um)')
         assert np.isclose(f.value, 1878.485)
 
+
 @pytest.mark.skipif('not HAS_SCIPY')
 def test_sun_binning():
     from scipy.integrate import trapz
-    
+
     # compare Sun's rebinning with an integration over the spectrum
     sun = Sun.from_builtin('E490_2014')
 
@@ -54,8 +62,9 @@ def test_sun_binning():
     fluxd1 = np.zeros(len(wave))
     for i in range(len(wave)):
         j = (wave0 >= left_bins[i]) * (wave0 <= right_bins[i])
-        fluxd1[i] = trapz(fluxd0[j] * wave0[j], wave0[j]) / trapz(wave0[j], wave0[j])
+        fluxd1[i] = trapz(fluxd0[j] * wave0[j], wave0[j]) / trapz(
+            wave0[j], wave0[j])
 
     fluxd2 = sun(wave * u.um).value
 
-    assert np.allclose(fluxd1, fluxd2)
+    assert np.allclose(fluxd1, fluxd2, 0.005)


### PR DESCRIPTION
Test of binning the solar spectrum is based on comparison of trapezoidal rule and `synphot`.  Revised to have a tolerance of 0.5%.