### PR TITLE
New Tracking context manager.

### DIFF
--- a/sbpy/bib/core.py
+++ b/sbpy/bib/core.py
@@ -17,6 +17,14 @@ Example
 sbpy.data.Ephem:
   implementation: Giorgini et al. 1996, 1996DPS....28.2504G
 
+Bibliography tracking can be used in a context manager::
+
+  >>> from sbpy import bib, data
+  >>> with bib.Tracking():
+  >>>     eph = data.Ephem.from_horizons('encke', epoch=None, observatory='500')
+  >>> bib.to_text()
+  JPL Horizons:
+    implementation: 1996DPS....28.2504G
 
 Functions
 ---------
@@ -28,9 +36,13 @@ reset    : clear bibliography.
 to_text  : output bibliography in clear text
 to_bibtex: output bibliography in bibtex format
 
+Context managers
+----------------
+Tracking : Bibliography tracking context manager.
+
 """
 
-__all__ = ['register', 'reset', 'status', 'stop', 'track',
+__all__ = ['register', 'reset', 'status', 'stop', 'track', 'Tracking',
            'to_text', 'to_bibtex']
 
 from collections import OrderedDict
@@ -79,7 +91,13 @@ def track():
     global _track
     _track = True
 
+class Tracking:
+    def __enter__(self):
+        track()
 
+    def __exit__(self, type, value, tb):
+        stop()
+    
 def to_text():
     """convert bibcodes to human readable text
 

--- a/sbpy/bib/tests/test_bib.py
+++ b/sbpy/bib/tests/test_bib.py
@@ -2,7 +2,7 @@
 import os
 import pytest
 from ...thermal import NEATM
-from .. import track, stop, reset, to_text, to_bibtex
+from .. import track, stop, register, reset, to_text, to_bibtex, Tracking
 
 
 # get file path of a static data file for testing
@@ -31,3 +31,14 @@ def test_bibtex():
         assert to_bibtex() == bib_file.read()
     reset()
     stop()
+
+
+def test_Tracking():
+    reset()
+    
+    with Tracking():
+        register('test', {'track this': 'bibcode'})
+
+    register('test', {'do not track this': 'bibcode'})
+
+    assert ['test:', 'track this:', 'bibcode'] == to_text().split()


### PR DESCRIPTION
Context manager for bibliography tracking so that one can pop in and out of tracking via:
```python
from sbpy import bib, data

with bib.Tracking():
    eph = data.Ephem.from_horizons('encke', epoch=None, observatory='500')

bib.to_text()
```