### PR TITLE
 Could not parse .travis.yml 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,7 @@ matrix:
         - os: linux
           env: ASTROPY_VERSION=lts
                EVENT_TYPE='pull_request push cron'
-	       
+
         # Try all python versions and Numpy versions. Since we can assume that
         # the Numpy developers have taken care of testing Numpy with different
         # versions of Python, we can vary Python and Numpy versions at the same


### PR DESCRIPTION
I suspect that the extra whitespace is causing the Travis build to fail again. Let's see if the build starts when the pull request is opened.